### PR TITLE
[HEAP-7991] Add support for Ubuntu 18.04

### DIFF
--- a/postgres/codenamemap.yaml
+++ b/postgres/codenamemap.yaml
@@ -45,10 +45,9 @@
 
 ## Ubuntu
 {{ debian_codename('trusty', '9.3') }}
-{{ debian_codename('precise', '9.4') }}
-{{ debian_codename('utopic', '9.4') }}
-{{ debian_codename('vivid', '9.4') }}
-{{ debian_codename('wily', '9.4') }}
 {{ debian_codename('xenial', '9.5') }}
+{{ debian_codename('artful', '9.6') }}
+{{ debian_codename('bionic', '10') }}
+{{ debian_codename('cosmic', '10') }}
 
 # vim: ft=sls


### PR DESCRIPTION
* Update `codenamemap` for Ubuntu

Modified for current supported versions as shown at:

* https://packages.ubuntu.com/search?keywords=postgresql&searchon=names